### PR TITLE
Add Pedro Raccoon Plymouth theme package and enable as boot theme

### DIFF
--- a/modules/system/bootanimation.nix
+++ b/modules/system/bootanimation.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  pkgs,
   hostVariables,
   ...
 }: {
@@ -9,11 +10,29 @@
   };
 
   config = lib.mkIf config.modules.system.bootanimation.enable {
+    boot.plymouth.themePackages = let
+      pedroRaccoonTheme = pkgs.stdenvNoCC.mkDerivation {
+        pname = "pedro-raccoon-plymouth";
+        version = "1.0";
+        src = pkgs.fetchzip {
+          url = "https://github.com/FilaCo/pedro-raccoon-plymouth/releases/download/v1.0/pedro-raccoon.zip";
+          hash = lib.fakeSha256; # TODO: replace with the real hash from nix-prefetch
+          stripRoot = false;
+        };
+        installPhase = ''
+          runHook preInstall
+          mkdir -p $out/share/plymouth/themes
+          cp -r ./* $out/share/plymouth/themes/
+          runHook postInstall
+        '';
+      };
+    in [pedroRaccoonTheme];
+
     # Plymouth aktivieren
     boot.plymouth.enable = true;
 
     # Optional: Theme auswählen
-    boot.plymouth.theme = "spinner"; # oder "spinner", "fade-in", "text", "tribar" …
+    boot.plymouth.theme = "pedro-raccoon"; # oder "spinner", "fade-in", "text", "tribar" …
 
     # Initrd muss systemd verwenden – hast du schon ✅
     boot.initrd.systemd.enable = true;


### PR DESCRIPTION
### Motivation
- Provide a packaged way to include the Pedro Raccoon Plymouth theme into the NixOS configuration so it can be enabled as the system boot theme. 
- Keep the configuration reproducible by fetching the theme as a derivation rather than relying on manual installation.

### Description
- Added `pkgs` to the function arguments of `modules/system/bootanimation.nix` and defined `boot.plymouth.themePackages` containing a `pedroRaccoonTheme` derivation. 
- The derivation uses `pkgs.fetchzip` to download the release zip from GitHub and an `installPhase` that installs files into `$out/share/plymouth/themes`. 
- Set `boot.plymouth.theme` to `"pedro-raccoon"` and left the fetch checksum as `lib.fakeSha256` with a `# TODO` comment to replace it via `nix-prefetch-url` before building.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69825cbc65788320ae63155fe90486c1)